### PR TITLE
Fix amico setup savepath description

### DIFF
--- a/python/doc/demos/NODDI_01.md
+++ b/python/doc/demos/NODDI_01.md
@@ -50,7 +50,7 @@ In the Python shell, import the AMICO library and setup/initialize the framework
 >>> amico.core.setup()
 ```
 
-This step will precompute all the necessary rotation matrices and store them in `~/.dypy`. Note that this setup/initialization step is necessary only once.
+This step will precompute all the necessary rotation matrices and store them in `~/.dipy`. Note that this setup/initialization step is necessary only once.
 
 
 ### Load the data


### PR DESCRIPTION
Seems like the file is saved to .dipy instead, probably a small typo in the instructions.

samuel ~ $ [~] ls .dipy/
total 24724
-rw-rw-r-- 1 samuel samuel 25295912 Mar 30 16:57 AMICO_aux_matrices_lmax=12.pickle
drwxrwxr-x 2 samuel samuel     4096 Feb  1 10:54 cenir_multib
drwxrwxr-x 3 samuel samuel     4096 Dec  3 14:15 exp_bundles_and_maps
drwxrwxr-x 2 samuel samuel     4096 Mar 30 16:31 isbi2013
drwxrwxr-x 2 samuel samuel     4096 Feb 23 13:17 sherbrooke_3shell
drwxrwxr-x 2 samuel samuel     4096 Jan 11 12:14 stanford_hardi

samuel ~ $ [~] ls .dypy
ls: cannot access .dypy: No such file or directory