### PR TITLE
Added the option to select a custom OUTPUT_path on ae.Evaluation or v…

### DIFF
--- a/python/amico/core.py
+++ b/python/amico/core.py
@@ -24,7 +24,7 @@ class Evaluation :
     evaluation with the AMICO framework.
     """
 
-    def __init__( self, study_path, subject ) :
+    def __init__( self, study_path, subject, output_path=None ) :
         """Setup the data structure with default values.
 
         Parameters
@@ -33,6 +33,9 @@ class Evaluation :
             The path to the folder containing all the subjects from one study
         subject : string
             The path (relative to previous folder) to the subject folder
+        OUTPUT_path : string
+            Optionally sets a custom full path for the output. Leave as None 
+            for default behaviour - output in study_path/subject/AMICO/<MODEL>
         """
         self.niiDWI      = None # set by "load_data" method
         self.niiDWI_img  = None
@@ -49,6 +52,7 @@ class Evaluation :
         self.set_config('study_path', study_path)
         self.set_config('subject', subject)
         self.set_config('DATA_path', pjoin( study_path, subject ))
+        self.set_config('OUTPUT_path', output_path)
 
         self.set_config('peaks_filename', None)
         self.set_config('doNormalizeSignal', True)
@@ -349,15 +353,22 @@ class Evaluation :
         """
         if self.RESULTS is None :
             raise RuntimeError( 'Model not fitted to the data; call "fit()" first.' )
-
-        RESULTS_path = pjoin( 'AMICO', self.model.id )
-        if path_suffix :
-            RESULTS_path = RESULTS_path +'_'+ path_suffix
-        self.RESULTS['RESULTS_path'] = RESULTS_path
-        print '\n-> Saving output to "%s/*":' % RESULTS_path
-
-        # delete previous output
-        RESULTS_path = pjoin( self.get_config('DATA_path'), RESULTS_path )
+        if self.get_config('OUTPUT_path') is None:
+            RESULTS_path = pjoin( 'AMICO', self.model.id )
+            if path_suffix :
+                RESULTS_path = RESULTS_path +'_'+ path_suffix
+            self.RESULTS['RESULTS_path'] = RESULTS_path
+            print '\n-> Saving output to "%s/*":' % RESULTS_path
+    
+            # delete previous output
+            RESULTS_path = pjoin( self.get_config('DATA_path'), RESULTS_path )
+        else:
+            RESULTS_path = self.get_config('OUTPUT_path')
+            if path_suffix :
+                RESULTS_path = RESULTS_path +'_'+ path_suffix
+            self.RESULTS['RESULTS_path'] = RESULTS_path
+            print '\n-> Saving output to "%s/*":' % RESULTS_path
+            
         if not exists( RESULTS_path ) :
             makedirs( RESULTS_path )
         else :

--- a/python/amico/progressbar.py
+++ b/python/amico/progressbar.py
@@ -1,3 +1,4 @@
+from os import fstat
 from sys import stdout
 from math import ceil
 
@@ -24,8 +25,9 @@ class ProgressBar :
         self.nbars  = 0
         self.prefix = prefix
         self.erase  = erase
-        print '\r%s[%s] %5.1f%%' % ( prefix, ' ' * width, 0.0 ),
-        stdout.flush()
+        if fstat(0)==fstat(1): #only show progress bar if stdout, False if redirected
+            print '\r%s[%s] %5.1f%%' % ( prefix, ' ' * width, 0.0 ),
+            stdout.flush()
 
 
     def update( self ) :
@@ -36,8 +38,9 @@ class ProgressBar :
         nbars = int( ceil(ratio * self.width) )
         if self.i == 1 or self.i == self.n or self.i or nbars != self.nbars:
             self.nbars = nbars
-            print '\r%s[%s%s] %5.1f%%' % ( self.prefix, '=' * self.nbars, ' ' * (self.width-self.nbars), 100.0*ratio),
-            stdout.flush()
+            if fstat(0)==fstat(1): #only show progress bar if stdout
+                print '\r%s[%s%s] %5.1f%%' % ( self.prefix, '=' * self.nbars, ' ' * (self.width-self.nbars), 100.0*ratio),
+                stdout.flush()
         self.i += 1
 
         if self.i > self.n :


### PR DESCRIPTION
…ia set_config('OUTPUT_path','path'). Default behaviour when None or not set.

Take a look and see what you think. The default behaviour is as you have currently specified, with the addition of an optional output_path variable setting in Evaluation or access through get/set_config with the key 'OUTPUT_path'.

Also, to keep the output file tidy when wrapping amico in a grid engine submission I added a check to the progress bar to determine if stdout has been redirected. If so, it is not updated. Should work on all platforms, but not tested fully.

Chris