### PR TITLE
Make compatible with Python 2.7 and 3.6

### DIFF
--- a/amico/__init__.py
+++ b/amico/__init__.py
@@ -1,10 +1,12 @@
-from core import Evaluation
-import core
-import scheme
-import lut
-import models
-import progressbar
-import util
+from __future__ import absolute_import, division, print_function
+
+from .core import Evaluation
+from . import core
+from . import scheme
+from . import lut
+from . import models
+from . import progressbar
+from . import util
 
 from pkg_resources import get_distribution
 __version__ = get_distribution('amico').version

--- a/amico/lut.py
+++ b/amico/lut.py
@@ -1,10 +1,13 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 from os import makedirs
 from os.path import isdir, isfile, join as pjoin
-import cPickle
+import pickle
 from dipy.data.fetcher import dipy_home
 from dipy.core.geometry import cart2sphere
 from dipy.reconst.shm import real_sym_sh_basis
+from dipy.utils.six.moves import xrange # see http://nipy.org/dipy/devel/python3.html
 import amico.scheme
 
 
@@ -22,7 +25,7 @@ def precompute_rotation_matrices( lmax = 12 ) :
     if isfile( filename ) :
         return
 
-    print '\n-> Precomputing rotation matrices for l_max=%d:' % lmax
+    print('\n-> Precomputing rotation matrices for l_max=%d:' % lmax)
     AUX = {}
     AUX['lmax'] = lmax
 
@@ -51,9 +54,9 @@ def precompute_rotation_matrices( lmax = 12 ) :
             i += 1
 
     with open( filename, 'wb+' ) as fid :
-        cPickle.dump( AUX, fid, protocol=2 )
+        pickle.dump( AUX, fid, protocol=2 )
 
-    print '   [ DONE ]'
+    print('   [ DONE ]')
 
 
 def load_precomputed_rotation_matrices( lmax = 12 ) :
@@ -67,7 +70,7 @@ def load_precomputed_rotation_matrices( lmax = 12 ) :
     filename = pjoin( dipy_home, 'AMICO_aux_matrices_lmax=%d.pickle'%lmax )
     if not isfile( filename ) :
         raise RuntimeError( 'Auxiliary matrices not found; call "lut.precompute_rotation_matrices()" first.' )
-    return cPickle.load( open(filename,'rb') )
+    return pickle.load( open(filename,'rb') )
 
 
 def aux_structures_generate( scheme, lmax = 12 ) :
@@ -87,7 +90,7 @@ def aux_structures_generate( scheme, lmax = 12 ) :
     idx_OUT : numpy array
         Indices of the SH corresponding to each shell
     """
-    nSH = (lmax+1)*(lmax+2)/2
+    nSH = (lmax+1)*(lmax+2)//2
     idx_IN  = []
     idx_OUT = []
     for s in xrange( len(scheme.shells) ) :
@@ -113,7 +116,7 @@ def aux_structures_resample( scheme, lmax = 12 ) :
     Ylm_OUT : numpy array
         Operator to transform each shell from Spherical harmonics to original signal space
     """
-    nSH = (lmax+1)*(lmax+2)/2
+    nSH = (lmax+1)*(lmax+2)//2
     idx_OUT = np.zeros( scheme.dwi_count, dtype=np.int32 )
     Ylm_OUT = np.zeros( (scheme.dwi_count,nSH*len(scheme.shells)), dtype=np.float32 ) # matrix from SH to real space
     idx = 0

--- a/amico/models.py
+++ b/amico/models.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 import numpy.matlib as matlib
 import scipy
@@ -9,6 +11,7 @@ import amico.lut
 from amico.progressbar import ProgressBar
 from dipy.core.gradients import gradient_table
 from dipy.sims.voxel import single_tensor
+from dipy.utils.six.moves import xrange # see http://nipy.org/dipy/devel/python3.html
 import abc
 
 import warnings
@@ -25,6 +28,7 @@ except ImportError:
 
 
 class BaseModel( object ) :
+#class BaseModel( object, metaclass=abc.ABCMeta ) :
     """Basic class to build a model; new models should inherit from this class.
     All the methods need to be overloaded to account for the specific needs of the model.
     Each method will then be called by a dispatcher when needed.
@@ -1068,10 +1072,10 @@ class FreeWater( BaseModel ) :
             self.maps_descr = [ 'fiber volume fraction',
                                 'Isotropic free-water volume fraction']
 
-        print '      %s settings for Freewater elimination... ' % self.type
-        print '             -iso  compartments: ', self.d_isos
-        print '             -perp compartments: ', self.d_perps
-        print '             -para compartments: ', self.d_par
+        print('      %s settings for Freewater elimination... ' % self.type)
+        print('             -iso  compartments: ', self.d_isos)
+        print('             -perp compartments: ', self.d_perps)
+        print('             -para compartments: ', self.d_par)
 
 
     def set_solver( self, lambda1 = 0.0, lambda2 = 1e-3 ):

--- a/amico/progressbar.py
+++ b/amico/progressbar.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 from os import fstat
 from sys import stdout
 from math import ceil
@@ -26,7 +28,7 @@ class ProgressBar :
         self.prefix = prefix
         self.erase  = erase
         if fstat(0)==fstat(1): #only show progress bar if stdout, False if redirected
-            print '\r%s[%s] %5.1f%%' % ( prefix, ' ' * width, 0.0 ),
+            print('\r%s[%s] %5.1f%%' % ( prefix, ' ' * width, 0.0 ), end=' ')
             stdout.flush()
 
 
@@ -39,13 +41,13 @@ class ProgressBar :
         if self.i == 1 or self.i == self.n or self.i or nbars != self.nbars:
             self.nbars = nbars
             if fstat(0)==fstat(1): #only show progress bar if stdout
-                print '\r%s[%s%s] %5.1f%%' % ( self.prefix, '=' * self.nbars, ' ' * (self.width-self.nbars), 100.0*ratio),
+                print('\r%s[%s%s] %5.1f%%' % ( self.prefix, '=' * self.nbars, ' ' * (self.width-self.nbars), 100.0*ratio), end=' ')
                 stdout.flush()
         self.i += 1
 
         if self.i > self.n :
             if self.erase :
-                print '\r' + ' ' * ( len(self.prefix) + self.width + 9 ) + '\r',
+                print('\r' + ' ' * ( len(self.prefix) + self.width + 9 ) + '\r', end=' ')
             else:
-                print
+                print()
             stdout.flush()

--- a/amico/scheme.py
+++ b/amico/scheme.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 from re import match as re_match
-import os.path
+from dipy.utils.six.moves import xrange # see http://nipy.org/dipy/devel/python3.html
+#import os.path
 
 class Scheme :
     """A class to hold information about an acquisition scheme.
@@ -34,9 +37,12 @@ class Scheme :
                         if re_match( r'[+-]?(\d+(\.\d*)?|\.\d+)([eE][+-]?\d+)?', line.strip() ) :
                             break
                         n += 1
+
                 tmp = np.loadtxt( data, skiprows=n )
+
             except :
                 raise IOError( 'Unable to open scheme file' )
+
             self.load_from_table( tmp, b0_thr )
         else :
             # try loading from matrix
@@ -62,8 +68,9 @@ class Scheme :
             data = np.expand_dims( data, axis=0 )
         self.raw = data
 
+
         # number of samples
-        self.nS = self.raw.shape[0]
+        # self.nS = self.raw.shape[0] JL: incomplete getter/setter incompatible with 3.6; this is never used any as getter always returns derived value
 
         # set/calculate the b-values
         if self.raw.shape[1] == 4 :
@@ -118,3 +125,5 @@ class Scheme :
     @property
     def nS( self ) :
         return self.b0_count + self.dwi_count
+
+

--- a/amico/util.py
+++ b/amico/util.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
 import os.path
 
@@ -45,10 +47,10 @@ def fsl2scheme( bvalsFilename, bvecsFilename, schemeFilename = None, flipAxes = 
     # if requested, round the b-values
     bStep = np.array(bStep, dtype = np.float)
     if bStep.size == 1 and bStep > 1.0:
-        print "-> Rounding b-values to nearest multiple of %s" % np.array_str(bStep)
+        print("-> Rounding b-values to nearest multiple of %s" % np.array_str(bStep))
         bvals = np.round(bvals/bStep) * bStep
     elif bStep.size > 1:
-        print "-> Setting b-values to the closest shell in %s" % np.array_str(bStep)
+        print("-> Setting b-values to the closest shell in %s" % np.array_str(bStep))
         for i in range(0, bvals.size):
             diff = min(abs(bvals[i] - bStep))
             ind = np.argmin(abs(bvals[i] - bStep))
@@ -56,11 +58,11 @@ def fsl2scheme( bvalsFilename, bvecsFilename, schemeFilename = None, flipAxes = 
             # warn if b > 99 is set to 0, possible error
             if (bStep[ind] == 0.0 and diff > 100) or (bStep[ind] > 0.0 and diff > bStep[ind] / 20.0):
                 # For non-zero shells, warn if actual b-value is off by more than 5%. For zero shells, warn above 50. Assuming s / mm^2
-                print "   Warning: measurement %d has b-value %d, being forced to %d\n'" % i, bvals[i], bStep[ind]
+                print("   Warning: measurement %d has b-value %d, being forced to %d\n'" % i, bvals[i], bStep[ind])
 
             bvals[i] = bStep[ind]
 
     # write corresponding scheme file
     np.savetxt( schemeFilename, np.c_[bvecs.T, bvals], fmt="%.06f", delimiter="\t", header="VERSION: BVECTOR", comments='' )
-    print "-> Writing scheme file to [ %s ]" % schemeFilename
+    print("-> Writing scheme file to [ %s ]" % schemeFilename)
     return schemeFilename


### PR DESCRIPTION
As your dependencies are compatible with Python 2.7 and 3.6 there was no reason to require Python 2.7. The majority of changes were simply in the PRINT function. Rather than evaluating the use of XRANGE and because you have DIPY as a dependency, I import from dipy.utils.six.moves import xrange. See [http://nipy.org/dipy/devel/python3.html](http://nipy.org/dipy/devel/python3.html)
After completing the changes. The results of the new code run under Python 2.7 and 3.6 were compared with a baseline result set run with the original code on Python 2.7. Results were identical out the 6th decimal.
