### PR TITLE
Fix datatype problems when saving maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 # Change Log
 All notable changes to AMICO will be documented in this file.
 
+## [1.2.9] - 2021-02-23
+
+### Added
+
+- Controls if files exist before opening
+
+### Fixed
+
+- Wrong datatype when saving results 
+
 ## [1.2.8] - 2021-01-29
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 description = 'Implementation of the linear framework for Accelerated Microstructure Imaging via Convex Optimization (AMICO) from diffusion MRI data'
 
 setup(name='dmri-amico',
-      version='1.2.8',
+      version='1.2.9',
       description='Accelerated Microstructure Imaging via Convex Optimization (AMICO)',
       long_description=description,
       author='Alessandro Daducci',


### PR DESCRIPTION
Fixes a bug introduced with PR #105 where a wrong datatype was used to save the output maps, i.e. `save_results`. This PR also fixes the problem when loading data but files do not exist (or paths are wrong); now the system prints an error instead of crashing