### PR TITLE
Changed required dependency numpy>=1.12,<1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to AMICO will be documented in this file.
 
+## [1.3.2] - 2022-01-14
+
+### Changed
+ - Changed required dependency numpy>=1.12,<1.22 
+
 ## [1.3.1] - 2021-12-03
 
 ### Fixed

--- a/amico/info.py
+++ b/amico/info.py
@@ -3,7 +3,7 @@
 # Format version as expected by setup.py (string of form "X.Y.Z")
 _version_major = 1
 _version_minor = 3
-_version_micro = 1
+_version_micro = 2
 _version_extra = '' #'.dev'
 __version__    = "%s.%s.%s%s" % (_version_major,_version_minor,_version_micro,_version_extra)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 wheel
 setuptools>=46.1
-numpy>=1.12
+numpy>=1.12,<1.22
 scipy>=1.0
 dipy>=1.0
 python-spams>=2.6.1

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(name=info.NAME,
       url=info.URL,
       license=info.LICENSE,
       packages=find_packages(),
-      setup_requires=['numpy>=1.12'],
-      install_requires=['wheel', 'numpy>=1.12', 'scipy>=1.0', 'dipy>=1.0', 'python-spams>=2.6.1', 'tqdm>=4.56.0', 'joblib>=1.0.1'],
+      setup_requires=['numpy>=1.12,<1.22'],
+      install_requires=['wheel', 'numpy>=1.12,<1.22', 'scipy>=1.0', 'dipy>=1.0', 'python-spams>=2.6.1', 'tqdm>=4.56.0', 'joblib>=1.0.1'],
       package_data={'': ['*.bin', 'directions/*.bin']})


### PR DESCRIPTION
This PR solves the issue #125 by restricting the version of numpy to be installed (`numpy>=1.12,<1.22`).