### PR TITLE
Fix import and data loading errors on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to AMICO will be documented in this file.
 
+## [1.4.4] - 2022-06-14
+
+### Fixed
+- Import error in 'util.py' on Windows systems
+- Loading errors in 'lut.py' on Windows systems
+
 ## [1.4.3] - 2022-05-18
 
 ### Fixed

--- a/amico/info.py
+++ b/amico/info.py
@@ -3,7 +3,7 @@
 # Format version as expected by setup.py (string of form "X.Y.Z")
 _version_major = 1
 _version_minor = 4
-_version_micro = 3
+_version_micro = 4
 _version_extra = '' #'.dev'
 __version__    = "%s.%s.%s%s" % (_version_major,_version_minor,_version_micro,_version_extra)
 

--- a/amico/lut.py
+++ b/amico/lut.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 import numpy as np
 from os import makedirs
 import sys
-from os.path import isdir, isfile, join as pjoin
+from os.path import isdir, isfile, dirname, join as pjoin
 import pickle
 from dipy.data.fetcher import dipy_home
 from dipy.core.geometry import cart2sphere
@@ -54,14 +54,14 @@ def load_directions( ndirs ):
     directions : np.array(shape=(ndirs, 3))
         Array with the 3D directions in cartesian coordinates
     """
-    amicopath = amico.__file__
-    pos = len(amicopath) - 1
-    while(amicopath[pos] != '/'):
-        pos = pos - 1
-    amicopath = amicopath[0 : pos] + '/directions/'
-    filename = f'ndirs={ndirs}.bin'
-    directions = np.fromfile(amicopath + filename, dtype=np.float64)
+    amicopath = dirname(amico.__file__)
+
+    filename = 'ndirs=%d.bin' % ndirs
+    directions_path = pjoin(amicopath, 'directions', filename)
+
+    directions = np.fromfile(directions_path, dtype=np.float64)
     directions = np.reshape(directions, (ndirs, 3))
+
     return directions
 
 
@@ -78,13 +78,13 @@ def load_precomputed_hash_table( ndirs ):
     hash_table : np.array(shape=ndirs)
         Array with the indexes for every high resolution direction
     """
-    amicopath = amico.__file__
-    pos = len(amicopath) - 1
-    while(amicopath[pos] != '/'):
-        pos = pos - 1
-    amicopath = amicopath[0 : pos] + '/directions/'
-    filename = f'htable_ndirs={ndirs}.bin'
-    hash_table = np.fromfile(amicopath + filename, dtype=np.int16)
+    amicopath = dirname(amico.__file__)
+
+    filename = 'htable_ndirs=%d.bin' % ndirs
+    hash_table_path = pjoin(amicopath, 'directions', filename)
+
+    hash_table = np.fromfile(hash_table_path, dtype=np.int16)
+
     return hash_table
 
 

--- a/amico/util.py
+++ b/amico/util.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 import os.path
-from os import EX_USAGE
 from sys import exit
 
 __VERBOSE_LEVEL__ = 3
@@ -45,7 +44,11 @@ def WARNING( msg, prefix='' ):
 def ERROR( msg, prefix='' ):
     if __VERBOSE_LEVEL__ >= 1:
         print( prefix+"\033[0;30;41m[ ERROR ]\033[0;31m %s\033[0m\n" % msg )
-    exit(EX_USAGE)
+    try:
+        from os import EX_USAGE # Only available on UNIX systems
+        exit(EX_USAGE)
+    except ImportError:
+        exit(1) # Exit with error code 1 if on Windows system
 
 
 def fsl2scheme( bvalsFilename, bvecsFilename, schemeFilename = None, flipAxes = [False,False,False], bStep = 1.0, delimiter = None ):


### PR DESCRIPTION
Fix #143 
Fixed:
- Import error in 'util.py' on Windows systems (the 'EX_USAGE' exit code is only available on Unix systems)
- Loading errors in 'lut.py' on Windows systems (in functions 'load_directions' and 'load_precomputed_hash_table')
