### PR TITLE
Check if DWI file is a 4D image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to AMICO will be documented in this file.
 ## [1.5.1] - 2022-09-21
 
 ### Fixed
--
+- Check if DWI file is a 4D image
 - Removed unused 'verbose' option in __init__ (now all is controleld by 'set_verbose')
 
 ## [1.5.0] - 2022-07-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to AMICO will be documented in this file.
 
+## [1.5.1] - 2022-09-21
+
+### Fixed
+-
+- Removed unused 'verbose' option in __init__ (now all is controleld by 'set_verbose')
+
 ## [1.5.0] - 2022-07-06
 
 ### Changed

--- a/amico/core.py
+++ b/amico/core.py
@@ -123,6 +123,8 @@ class Evaluation :
         self.niiDWI  = nibabel.load( pjoin(self.get_config('DATA_path'), dwi_filename) )
         self.niiDWI_img = self.niiDWI.get_data().astype(np.float32)
         hdr = self.niiDWI.header if nibabel.__version__ >= '2.0.0' else self.niiDWI.get_header()
+        if self.niiDWI_img.ndim != 4 :
+            ERROR( 'DWI file is not a 4D image' )
         self.set_config('dim', self.niiDWI_img.shape[:3])
         self.set_config('pixdim', tuple( hdr.get_zooms()[:3] ))
         PRINT('\t\t- dim    = %d x %d x %d x %d' % self.niiDWI_img.shape)
@@ -159,7 +161,7 @@ class Evaluation :
             PRINT('\t\t- dim    = %d x %d x %d' % self.niiMASK_img.shape[:3])
             PRINT('\t\t- pixdim = %.3f x %.3f x %.3f' % niiMASK_hdr.get_zooms()[:3])
             if self.niiMASK.ndim != 3 :
-                ERROR( 'The provided MASK if 4D, but a 3D dataset is expected' )
+                ERROR( 'MASK file is not a 3D image' )
             if self.get_config('dim') != self.niiMASK_img.shape[:3] :
                 ERROR( 'MASK geometry does not match with DWI data' )
         else :

--- a/amico/core.py
+++ b/amico/core.py
@@ -47,7 +47,7 @@ class Evaluation :
     evaluation with the AMICO framework.
     """
 
-    def __init__( self, study_path, subject, output_path=None, verbose=2 ) :
+    def __init__( self, study_path, subject, output_path=None ) :
         """Setup the data structure with default values.
 
         Parameters
@@ -59,8 +59,6 @@ class Evaluation :
         output_path : string
             Optionally sets a custom full path for the output. Leave as None
             for default behaviour - output in study_path/subject/AMICO/<MODEL>
-        verbose : int
-            Possible values: 2->show all, 1->hide progress bars, 0->hide all
         """
         self.niiDWI      = None # set by "load_data" method
         self.niiDWI_img  = None
@@ -91,7 +89,6 @@ class Evaluation :
         self.set_config('DWI-SNR', None)                # SNR of DWI image: SNR = b0/sigma
         self.set_config('doDirectionalAverage', False)  # To perform the directional average on the signal of each shell
         self.set_config('parallel_jobs', -1)            # Number of jobs to be used in multithread-enabled parts of code
-        self.set_config('verbose', verbose)
 
     def set_config( self, key, value ) :
         self.CONFIG[ key ] = value

--- a/amico/info.py
+++ b/amico/info.py
@@ -3,7 +3,7 @@
 # Format version as expected by setup.py (string of form "X.Y.Z")
 _version_major = 1
 _version_minor = 5
-_version_micro = 0
+_version_micro = 1
 _version_extra = '' #'.dev'
 __version__    = "%s.%s.%s%s" % (_version_major,_version_minor,_version_micro,_version_extra)
 


### PR DESCRIPTION
When a 5D image is fed, e.g. the 5th dimension is used to store the diffusion measurements instead of the 4th, AMICO does not consider this eventuality and crashes. Now, a check is added to control for this situation.