### PR TITLE
Data loading: check for "bad voxels" (NaN or Inf values) when load and pre-process data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to AMICO will be documented in this file.
 
+## [1.5.2] - 2022-10-21
+
+### Added
+- 'b0_min_signal' parameter in 'load_data()' to crop to zero the signal in voxels where the b0 <= b0_min_signal * mean(b0[b0 > 0])
+- 'replace_bad_voxels' parameter in 'load_data()' to replace NaN and Inf values in the signal
+
 ## [1.5.1] - 2022-09-21
 
 ### Fixed

--- a/amico/core.py
+++ b/amico/core.py
@@ -124,6 +124,8 @@ class Evaluation :
         if not isfile( pjoin(self.get_config('DATA_path'), dwi_filename) ):
             ERROR( 'DWI file not found' )
         self.set_config('dwi_filename', dwi_filename)
+        self.set_config('b0_min_signal', b0_min_signal)
+        self.set_config('replace_bad_voxels', replace_bad_voxels)
         self.niiDWI  = nibabel.load( pjoin(self.get_config('DATA_path'), dwi_filename) )
         self.niiDWI_img = self.niiDWI.get_data().astype(np.float32)
         hdr = self.niiDWI.header if nibabel.__version__ >= '2.0.0' else self.niiDWI.get_header()
@@ -181,6 +183,7 @@ class Evaluation :
             self.niiMASK = None
             self.niiMASK_img = np.ones( self.get_config('dim') )
             PRINT('\t\t- not specified')
+        self.set_config('mask_filename', mask_filename)
         PRINT(f'\t\t- voxels = {np.count_nonzero(self.niiMASK_img)}')
 
         LOG( f'   [ {time.time() - tic:.1f} seconds ]' )

--- a/amico/info.py
+++ b/amico/info.py
@@ -3,7 +3,7 @@
 # Format version as expected by setup.py (string of form "X.Y.Z")
 _version_major = 1
 _version_minor = 5
-_version_micro = 1
+_version_micro = 2
 _version_extra = '' #'.dev'
 __version__    = "%s.%s.%s%s" % (_version_major,_version_minor,_version_micro,_version_extra)
 


### PR DESCRIPTION
Added:
- 'b0_min_signal' parameter in 'load_data()' (as in [COMMIT](https://github.com/daducci/commit))
- 'replace_bad_voxels' parameter in 'load_data()' to replace NaN and Inf values in the signal