### PR TITLE
v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to AMICO will be documented in this file.
 
+## [1.5.3] - 2023-01-20
+
+### Fixed
+- Problem with the 'set_solver()' method that raise a 'multiple values for keyword argument' error
+
 ## [1.5.2] - 2022-10-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change Log
 All notable changes to AMICO will be documented in this file.
 
-## [1.5.3] - 2023-01-20
+## [1.5.3] - 2023-01-23
 
 ### Fixed
-- Problem with the 'set_solver()' method that raise a 'multiple values for keyword argument' error
+- Problem with the `set_solver()` method that raise a `multiple values for keyword argument` error
+- Replaced `np.bool`, `np.float` and `np.object` deprecated aliases (raise `AttributeError` with NumPy >= v1.24.0)
 
 ## [1.5.2] - 2022-10-21
 

--- a/amico/info.py
+++ b/amico/info.py
@@ -3,7 +3,7 @@
 # Format version as expected by setup.py (string of form "X.Y.Z")
 _version_major = 1
 _version_minor = 5
-_version_micro = 2
+_version_micro = 3
 _version_extra = '' #'.dev'
 __version__    = "%s.%s.%s%s" % (_version_major,_version_minor,_version_micro,_version_extra)
 

--- a/amico/lut.py
+++ b/amico/lut.py
@@ -116,7 +116,7 @@ def precompute_rotation_matrices( lmax, ndirs ) :
     AUX['fit'] = np.dot( np.linalg.pinv( np.dot(tmp.T,tmp) ), tmp.T )
 
     # matrices to rotate the functions in SH space
-    AUX['Ylm_rot'] = np.zeros( ndirs, dtype=np.object )
+    AUX['Ylm_rot'] = np.zeros( ndirs, dtype=np.object_ )
     for i in range(ndirs):
         _, theta, phi = cart2sphere(directions[i][0], directions[i][1], directions[i][2])
         tmp, _, _ = real_sym_sh_basis( lmax, theta, phi )

--- a/amico/util.py
+++ b/amico/util.py
@@ -82,7 +82,7 @@ def fsl2scheme( bvalsFilename, bvecsFilename, schemeFilename = None, flipAxes = 
         ERROR( 'incorrect/incompatible bval/bvecs files' )
 
     # if requested, flip the axes
-    flipAxes = np.array(flipAxes, dtype = np.bool)
+    flipAxes = np.array(flipAxes, dtype = np.bool_)
     if flipAxes.ndim != 1 or flipAxes.size != 3 :
         ERROR( '"flipAxes" must contain 3 boolean values (one for each axis)' )
     if flipAxes[0] :
@@ -93,7 +93,7 @@ def fsl2scheme( bvalsFilename, bvecsFilename, schemeFilename = None, flipAxes = 
         bvecs[2,:] *= -1
 
     # if requested, round the b-values
-    bStep = np.array(bStep, dtype = np.float)
+    bStep = np.array(bStep, dtype = np.double)
     if bStep.size == 1 and bStep > 1.0:
         PRINT("-> Rounding b-values to nearest multiple of %s" % np.array_str(bStep))
         bvals = np.round(bvals/bStep) * bStep
@@ -193,7 +193,7 @@ def sandi2scheme( bvalsFilename, bvecsFilename, Delta_data, smalldel_data, TE_da
                 ERROR('The value TE < (Delta + delta) ')
 
     # if requested, flip the axes
-    flipAxes = np.array(flipAxes, dtype = np.bool)
+    flipAxes = np.array(flipAxes, dtype = np.bool_)
     if flipAxes.ndim != 1 or flipAxes.size != 3 :
         ERROR( '"flipAxes" must contain 3 boolean values (one for each axis)' )
     if flipAxes[0] :
@@ -204,7 +204,7 @@ def sandi2scheme( bvalsFilename, bvecsFilename, Delta_data, smalldel_data, TE_da
         bvecs[2,:] *= -1
 
     # if requested, round the b-values
-    bStep = np.array(bStep, dtype = np.float)
+    bStep = np.array(bStep, dtype = np.double)
     if bStep.size == 1 and bStep > 1.0:
         PRINT("-> Rounding b-values to nearest multiple of %s" % np.array_str(bStep))
         bvals = np.round(bvals/bStep) * bStep


### PR DESCRIPTION
### Fixed
- Problem with the `set_solver()` method that raise a `multiple values for keyword argument` error
- Replaced `np.bool`, `np.float` and `np.object` deprecated aliases (raise `AttributeError` with NumPy >= v1.24.0)