### PR TITLE
v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Change Log
 All notable changes to AMICO will be documented in this file.
 
-## [1.5.4] - 2023-02-14
+## [1.5.4] - 2023-02-15
 
 ### Fixed
-- Invalid command 'bdist_wheel' error when install with pip<=20.0.2
+- `invalid command 'bdist_wheel'` error when install with pip <= v20.0.2
+- [#155](https://github.com/daducci/AMICO/issues/155) Replaced the NiBabel `get_data()` method with `get_fdata()` (raise `ExpiredDeprecationError` with NiBabel >= v5.0.0)
 
 ## [1.5.3] - 2023-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to AMICO will be documented in this file.
 
+## [1.5.4] - 2023-02-14
+
+### Fixed
+- Invalid command 'bdist_wheel' error when install with pip<=20.0.2
+
 ## [1.5.3] - 2023-01-23
 
 ### Fixed

--- a/amico/core.py
+++ b/amico/core.py
@@ -128,7 +128,7 @@ class Evaluation :
         self.set_config('b0_min_signal', b0_min_signal)
         self.set_config('replace_bad_voxels', replace_bad_voxels)
         self.niiDWI  = nibabel.load( pjoin(self.get_config('DATA_path'), dwi_filename) )
-        self.niiDWI_img = self.niiDWI.get_data().astype(np.float32)
+        self.niiDWI_img = self.niiDWI.get_fdata().astype(np.float32)
         hdr = self.niiDWI.header if nibabel.__version__ >= '2.0.0' else self.niiDWI.get_header()
         if self.niiDWI_img.ndim != 4 :
             ERROR( 'DWI file is not a 4D image' )
@@ -172,7 +172,7 @@ class Evaluation :
             if not isfile( pjoin(self.get_config('DATA_path'), mask_filename) ):
                 ERROR( 'MASK file not found' )
             self.niiMASK  = nibabel.load( pjoin( self.get_config('DATA_path'), mask_filename) )
-            self.niiMASK_img = self.niiMASK.get_data().astype(np.uint8)
+            self.niiMASK_img = self.niiMASK.get_fdata().astype(np.uint8)
             niiMASK_hdr = self.niiMASK.header if nibabel.__version__ >= '2.0.0' else self.niiMASK.get_header()
             PRINT('\t\t- dim    = %d x %d x %d' % self.niiMASK_img.shape[:3])
             PRINT('\t\t- pixdim = %.3f x %.3f x %.3f' % niiMASK_hdr.get_zooms()[:3])
@@ -479,7 +479,7 @@ class Evaluation :
             if not isfile( pjoin(self.get_config('DATA_path'), peaks_filename) ):
                 ERROR( 'PEAKS file not found' )
             niiPEAKS = nibabel.load( pjoin( self.get_config('DATA_path'), peaks_filename) )
-            DIRs = niiPEAKS.get_data().astype(np.float32)
+            DIRs = niiPEAKS.get_fdata().astype(np.float32)
             nDIR = np.floor( DIRs.shape[3]/3 )
             PRINT('\t* peaks dim = %d x %d x %d x %d' % DIRs.shape[:4])
             if DIRs.shape[:3] != self.niiMASK_img.shape[:3] :

--- a/amico/info.py
+++ b/amico/info.py
@@ -3,7 +3,7 @@
 # Format version as expected by setup.py (string of form "X.Y.Z")
 _version_major = 1
 _version_minor = 5
-_version_micro = 3
+_version_micro = 4
 _version_extra = '' #'.dev'
 __version__    = "%s.%s.%s%s" % (_version_major,_version_minor,_version_micro,_version_extra)
 

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(name=info.NAME,
       url=info.URL,
       license=info.LICENSE,
       packages=find_packages(),
-      install_requires=['packaging', 'wheel', 'numpy>=1.12', 'scipy>=1.0', 'dipy>=1.0', 'spams>=2.6.5.2', 'tqdm>=4.56.0', 'joblib>=1.0.1'],
+      setup_requires=['wheel'],
+      install_requires=['packaging', 'numpy>=1.12', 'scipy>=1.0', 'dipy>=1.0', 'spams>=2.6.5.2', 'tqdm>=4.56.0', 'joblib>=1.0.1'],
       package_data={'': ['*.bin', 'directions/*.bin']})


### PR DESCRIPTION
## (1) `invalid command 'bdist_wheel'` error message when install
### Behaviour
Running `pip install dmri-amico` with `pip<=20.0.2` installs correctly the package, but this error message is shown:
```bash
Building wheel for dmri-amico (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/clori/commit_test/venv/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-kvffddp6/dmri-amico/setup.py'"'"'; __file__='"'"'/tmp/pip-install-kvffddp6/dmri-amico/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-mks5ujyr
       cwd: /tmp/pip-install-kvffddp6/dmri-amico/
  Complete output (6 lines):
  usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: setup.py --help [cmd1 cmd2 ...]
     or: setup.py --help-commands
     or: setup.py cmd --help

  error: invalid command 'bdist_wheel'
  ----------------------------------------
  ERROR: Failed building wheel for dmri-amico
```
### Runtime info
OS: Ubuntu-20.04
Python: 3.8.10
pip: 20.0.2

---

## (2) Fix #155
Replaced the NiBabel `get_data()` deprecated method with `get_fdata()` (raise `ExpiredDeprecationError` with NiBabel >= v5.0.0)