### PR TITLE
Allow separate blas/lapack library names/paths to be specified in site.cfg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,17 @@ if not isfile('site.cfg'):
       exit(1)
 config = ConfigParser()
 config.read('site.cfg')
+
 try:
-      libraries.extend([config['openblas']['library']])
-      library_dirs.extend([config['openblas']['library_dir']])
-      include_dirs.extend([config['openblas']['include_dir']])
-except KeyError as err:
-      print(f'\033[31mKeyError: cannot find the {err} key in the site.cfg file. See the site.cfg.example file for documentation\033[0m')
+      for lib in ('blas', 'lapack', 'openblas'):
+            if lib in config:
+                  libraries.extend([config[lib]['library']])
+                  library_dirs.extend([config[lib]['library_dir']])
+                  include_dirs.extend([config[lib]['include_dir']])
+      if len(libraries) == 0:
+            raise KeyError()
+except Exception:
+      print(f'\033[31mCannot find BLAS/LAPACK/OpenBLAS paths in the site.cfg file. See the site.cfg.example file for documentation\033[0m')
       exit(1)
 
 if sys.platform.startswith('win32'):


### PR DESCRIPTION
Howdy,

This PR makes a very small change to `setup.py` to allow separate library names/paths to be specified for the BLAS/LAPACK implementations, rather than assuming that all BLAS/LAPACK functions are provided by a single library. It modifies the expected `site.cfg` file format so that separate `blas` and `lapack` sections are supported, in addition to the already-supported `openblas` section.

Thanks!