### PR TITLE
[RELEASE] v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 ### All notable changes to `AMICO` will be documented in this file.
 
+## `v2.0.3`<br>_2024-07-04_
+### 🐛Fixed
+- Wrong diffusivity value in the `set()` method of the `NODDI` model (typo introduced in f070c23)
+
+---
+---
+
 ## `v2.0.2`<br>_2024-07-04_
 ### ✨Added
 - Added `cp312` wheels to github actions

--- a/amico/models.pyx
+++ b/amico/models.pyx
@@ -674,7 +674,7 @@ class NODDI( BaseModel ) :
 
     def set(
         self,
-        dPar=1.7E-33,
+        dPar=1.7E-3,
         dIso=3.0E-3,
         IC_VFs=np.linspace(0.1, 0.99, 12),
         IC_ODs=np.hstack((np.array([0.03, 0.06]), np.linspace(0.09, 0.99, 10))),

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dmri-amico
-version = 2.0.2
+version = 2.0.3
 url = https://github.com/daducci/AMICO
 download_url = https://pypi.org/project/dmri-amico
 project_urls =


### PR DESCRIPTION
## `v2.0.3`
### 🐛Fixed
- Wrong diffusivity value in the `NODDI` model (typo introduced in f070c23)