### PR TITLE
[RELEASE] v2.1.0

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -9,7 +9,7 @@ jobs:
   build_windows_wheels:
     strategy:
       matrix:
-        py: [cp36, cp37, cp38, cp39, cp310, cp311, cp312]
+        py: [cp36, cp37, cp38, cp39, cp310, cp311, cp312, cp313]
         arch:
           - [AMD64, win_amd64, x64]
           - [x86, win32, x86]
@@ -29,7 +29,7 @@ jobs:
           python setup_site.py openblas libopenblas ${{ github.workspace }}\OpenBLAS\lib ${{ github.workspace }}\OpenBLAS\include
 
       - name: Build wheel ${{ matrix.py }}-${{ matrix.arch[1] }}
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_PLATFORM: windows
           CIBW_BUILD: ${{ matrix.py }}-${{ matrix.arch[1] }}
@@ -80,6 +80,10 @@ jobs:
               arch: [x86_64, macosx_x86_64, 12.0, macos-12]
             },
             {
+              py: cp313,
+              arch: [x86_64, macosx_x86_64, 12.0, macos-12]
+            },
+            {
               py: cp38,
               arch: [arm64, macosx_arm64, 12.0, macos-14]
             },
@@ -97,6 +101,10 @@ jobs:
             },
             {
               py: cp312,
+              arch: [arm64, macosx_arm64, 12.0, macos-14]
+            },
+            {
+              py: cp313,
               arch: [arm64, macosx_arm64, 12.0, macos-14]
             }
           ]
@@ -125,7 +133,7 @@ jobs:
           python3 setup_site.py openblas openblas ${{ github.workspace }}/OpenBLAS/lib ${{ github.workspace }}/OpenBLAS/include
 
       - name: Build wheel ${{ matrix.config.py }}-${{ matrix.config.arch[1] }}
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_ENVIRONMENT_MACOS: >
             MACOSX_DEPLOYMENT_TARGET=${{ matrix.config.arch[2] }}
@@ -145,7 +153,7 @@ jobs:
   build_linux_wheels:
     strategy:
       matrix:
-        py: [cp36, cp37, cp38, cp39, cp310, cp311, cp312]
+        py: [cp36, cp37, cp38, cp39, cp310, cp311, cp312, cp313]
         arch:
           - [x86_64, manylinux_x86_64, amd64]
           - [aarch64, manylinux_aarch64, arm64]
@@ -173,7 +181,7 @@ jobs:
           platforms: ${{ matrix.arch[2] }}
 
       - name: Build wheel ${{ matrix.py }}-${{ matrix.arch[1] }}
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_PLATFORM: linux
           CIBW_BUILD: ${{ matrix.py }}-${{ matrix.arch[1] }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -53,35 +53,35 @@ jobs:
           [
             {
               py: cp36,
-              arch: [x86_64, macosx_x86_64, 12.0, macos-12]
+              arch: [x86_64, macosx_x86_64, 12.0, macos-13]
             },
             {
               py: cp37,
-              arch: [x86_64, macosx_x86_64, 12.0, macos-12]
+              arch: [x86_64, macosx_x86_64, 12.0, macos-13]
             },
             {
               py: cp38,
-              arch: [x86_64, macosx_x86_64, 12.0, macos-12]
+              arch: [x86_64, macosx_x86_64, 12.0, macos-13]
             },
             {
               py: cp39,
-              arch: [x86_64, macosx_x86_64, 12.0, macos-12]
+              arch: [x86_64, macosx_x86_64, 12.0, macos-13]
             },
             {
               py: cp310,
-              arch: [x86_64, macosx_x86_64, 12.0, macos-12]
+              arch: [x86_64, macosx_x86_64, 12.0, macos-13]
             },
             {
               py: cp311,
-              arch: [x86_64, macosx_x86_64, 12.0, macos-12]
+              arch: [x86_64, macosx_x86_64, 12.0, macos-13]
             },
             {
               py: cp312,
-              arch: [x86_64, macosx_x86_64, 12.0, macos-12]
+              arch: [x86_64, macosx_x86_64, 12.0, macos-13]
             },
             {
               py: cp313,
-              arch: [x86_64, macosx_x86_64, 12.0, macos-12]
+              arch: [x86_64, macosx_x86_64, 12.0, macos-13]
             },
             {
               py: cp38,

--- a/.github/workflows/compile_openblas_macos.yml
+++ b/.github/workflows/compile_openblas_macos.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         arch:
-          - [x86_64, SANDYBRIDGE, 12.0, macos-12]
+          - [x86_64, SANDYBRIDGE, 12.0, macos-13]
           - [arm64, ARMV8, 12.0, macos-14]
     name: ${{ matrix.arch[0] }}
     runs-on: ${{ matrix.arch[3] }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 ### All notable changes to `AMICO` will be documented in this file.
 
+## `v2.1.0`<br>_2025-01-20_
+### 🛠️Changed
+- Support for `numpy>=2.0.0`
+
+### 🐛Fixed
+- `UserWarning`: pass `bvals` and `bvecs` as keyword args in `dipy.core.gradients.gradient_table`
+
+---
+---
+
 ## `v2.0.3`<br>_2024-07-04_
 ### 🐛Fixed
 - Wrong diffusivity value in the `set()` method of the `NODDI` model (typo introduced in f070c23)

--- a/amico/core.py
+++ b/amico/core.py
@@ -432,7 +432,7 @@ class Evaluation :
             if self.get_config('doMergeB0'):
                 gtab = gradient_table( np.hstack((0,self.scheme.b[self.scheme.dwi_idx])), np.vstack((np.zeros((1,3)),self.scheme.raw[self.scheme.dwi_idx,:3])) )
             else:
-                gtab = gradient_table( self.scheme.b, self.scheme.raw[:,:3] )
+                gtab = gradient_table( bvals=self.scheme.b, bvecs=self.scheme.raw[:,:3] )
             DTI = dti.TensorModel( gtab, fit_method=self.get_config('DTI_fit_method'))
         else :
             if not isfile( pjoin(self.get_config('DATA_path'), peaks_filename) ):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = dmri-amico
-version = 2.0.3
+version = 2.1.0
 url = https://github.com/daducci/AMICO
 download_url = https://pypi.org/project/dmri-amico
 project_urls =
@@ -34,7 +34,7 @@ keywords =
 [options]
 zip_safe = False
 install_requires =
-    numpy>=1.19.5, <2.0.0
+    numpy>=1.19.5
     scipy>=1.5.4
     dipy>=1.4.1
     threadpoolctl>=3.1.0


### PR DESCRIPTION
## `v2.1.0`<br>_2025-01-20_
### 🛠️Changed
- Support for `numpy>=2.0.0`

### 🐛Fixed
- `UserWarning`: pass `bvals` and `bvecs` as keyword args in `dipy.core.gradients.gradient_table`