### PR TITLE
Ensure the input binary mask is actually binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 ### All notable changes to `AMICO` will be documented in this file.
 
-## `v2.1.1`<br>_2025-08-13_
+## `v2.1.1`<br>_2025-12-17_
 ### 🐛Fixed
 - `UserWarning`: `pkg_resources` is deprecated as an API.
+- Ensure the input mask is binary
 
 ---
 ---

--- a/amico/core.py
+++ b/amico/core.py
@@ -177,7 +177,7 @@ class Evaluation :
             if not isfile( pjoin(self.get_config('DATA_path'), mask_filename) ):
                 ERROR( 'MASK file not found' )
             self.niiMASK = nibabel.load( pjoin( self.get_config('DATA_path'), mask_filename) )
-            self.niiMASK_img = self.niiMASK.get_fdata().astype(np.uint8)
+            self.niiMASK_img = (self.niiMASK.get_fdata()>0).astype(np.uint8)
             niiMASK_hdr = self.niiMASK.header if nibabel.__version__ >= '2.0.0' else self.niiMASK.get_header()
             PRINT('\t\t- dim    = %d x %d x %d' % self.niiMASK_img.shape[:3])
             PRINT('\t\t- pixdim = %.3f x %.3f x %.3f' % niiMASK_hdr.get_zooms()[:3])


### PR DESCRIPTION
Ensure that the input binary mask (i.e., parameter `mask_filename` in `load_data()`) is actually binary; if not, binarize it.